### PR TITLE
Detect yaml filetype for -o yaml output

### DIFF
--- a/ftdetect/kubeconf.vim
+++ b/ftdetect/kubeconf.vim
@@ -9,7 +9,7 @@ function s:DetectKubernetes() abort
     return
   endif
   let l:first_line = getline(1)
-  if l:first_line =~# '^apiVersion: ' || l:first_line =~# '^kind: '
+  if l:first_line =~# '^\(kind\|apiVersion\): '
     set filetype=yaml
   endif
 endfunction

--- a/ftdetect/kubeconf.vim
+++ b/ftdetect/kubeconf.vim
@@ -2,3 +2,15 @@
 autocmd BufRead,BufNewFile */.kube/config set filetype=yaml
 
 autocmd BufRead,BufNewFile */templates/*.yaml,*/templates/*.tpl set filetype=yaml.gotexttmpl
+
+" Detect kubectl get X -oyaml | vim (no file)
+function s:DetectKubernetes() abort
+  if did_filetype() || &ft != ''
+    return
+  endif
+  let l:first_line = getline(1)
+  if l:first_line =~# '^apiVersion: ' || l:first_line =~# '^kind: '
+    set filetype=yaml
+  endif
+endfunction
+autocmd BufNewFile,BufRead,BufEnter * call s:DetectKubernetes()


### PR DESCRIPTION
for when opening manifest with `-oyaml`, example:
```
kubectl get service --namespace kube-system kube-dns -o yaml | vim
```